### PR TITLE
add ember version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/ember-component-inbound-actions.svg)](https://badge.fury.io/js/ember-component-inbound-actions)
 [![Build Status](https://travis-ci.org/GavinJoyce/ember-component-inbound-actions.svg?branch=master)](https://travis-ci.org/GavinJoyce/ember-component-inbound-actions)
+![Ember Version](https://embadge.io/v1/badge.svg?start=1.13.0)
 
 Send actions to Ember.js components. Inspired by [Sam Selikoff's blog post](http://www.samselikoff.com/blog/2014/05/16/getting-ember-components-to-respond-to-actions/)
 


### PR DESCRIPTION
#23 is "dropping" ember 1.13 support. I like to be explicit in what addon version supports what ember version.